### PR TITLE
Add full width to comments, flush right

### DIFF
--- a/client/@/css/app.css
+++ b/client/@/css/app.css
@@ -73,8 +73,9 @@ pre {
   white-space: pre-wrap;
 }
 
-nav .icon, nav a,
-ul.comments, main.details ul > li,
+nav .icon, 
+nav a,
+main.details > ul > li,
 main.about pre {
   padding: var(--padding);
 }
@@ -87,8 +88,10 @@ nav .icon, nav a
 }
 
 ul.comments {
-  padding-bottom: 0;
   margin-bottom: 0;
+  margin-top: calc(var(--padding) * 4);
+  padding-bottom: calc(var(--padding) * 2);
+  padding-left: calc(var(--padding) * 2);
 }
 
 nav a, nav a:visited {
@@ -111,10 +114,15 @@ main {
   transition: opacity .3s;
 }
 
-article, main.details li {
+article,
+main.details li {
   width: 100%;
   opacity: 1;
   transition: opacity .3s;
+}
+
+main.details li {
+  padding-top: var(--padding);
 }
 
 article.placeholder,

--- a/client/@/css/app.css
+++ b/client/@/css/app.css
@@ -89,9 +89,14 @@ nav .icon, nav a
 
 ul.comments {
   margin-bottom: 0;
-  margin-top: calc(var(--padding) * 4);
+  margin-top: var(--padding);
   padding-bottom: calc(var(--padding) * 2);
   padding-left: calc(var(--padding) * 2);
+}
+
+[dir="rtl"] ul.comments {
+  padding-inline-end: 0;
+  padding-inline-start: calc(var(--padding) * 2);
 }
 
 nav a, nav a:visited {


### PR DESCRIPTION
Comment threads shrank with more nesting, centered away from left and right sides. Now nested comment threads are flush right to full width minus the left padding for each nested list.

Before and After:
![hn-spacing](https://user-images.githubusercontent.com/454064/84581712-14df4700-ad99-11ea-887f-57c277ad327e.jpg)

